### PR TITLE
Replacing Downloads Center with Commons

### DIFF
--- a/public/Henry Agnew/Commons/src/components/LibreText.jsx
+++ b/public/Henry Agnew/Commons/src/components/LibreText.jsx
@@ -152,7 +152,7 @@ export default function LibreText(props) {
 							<AccordionDetails style={{overflowX: "auto"}}>
 								<a href={`${root}/Full.pdf`} className={'mt-icon-file-pdf'}
 								   target='_blank'>Download Full PDF
-								<iframe src={`${root}/Full.pdf?view=true`} height={500}/>
+								<iframe src={`${root}/Preview.pdf?view=true`} height={500}/>
 								</a>
 							</AccordionDetails>
 						</Accordion>

--- a/public/Henry Agnew/Commons/src/components/LibreText.jsx
+++ b/public/Henry Agnew/Commons/src/components/LibreText.jsx
@@ -74,7 +74,7 @@ export default function LibreText(props) {
 		}, []);
 		
 		return (
-			<Dialog id="Commons-Learn-More" onClose={handleClose} aria-labelledby="customized-dialog-title" open={open}>
+			<Dialog id="Commons-Learn-More" onClose={handleClose} aria-labelledby="customized-dialog-title" maxWidth="md" open={open}>
 				<DialogTitle onClose={handleClose}>
 					{props.item.title}
 				</DialogTitle>
@@ -149,11 +149,10 @@ export default function LibreText(props) {
 								aria-controls="panel3a-content">
 								<Typography>Book Preview</Typography>
 							</AccordionSummary>
-							<AccordionDetails style={{overflowX: "auto"}}>
+							<AccordionDetails style={{overflowX: "auto", flexDirection:'column'}}>
 								<a href={`${root}/Full.pdf`} className={'mt-icon-file-pdf'}
-								   target='_blank'>Download Full PDF
+								   target='_blank'>Download Full PDF</a>
 								<iframe src={`${root}/Preview.pdf?view=true`} height={500}/>
-								</a>
 							</AccordionDetails>
 						</Accordion>
 						{/*<Accordion>


### PR DESCRIPTION
Project to replace the current Downloads Center with a more flexible Commons. Also will be used for institution portals.

Beta available: https://chem.libretexts.org/Courses/Remixer_University/Download_Center/Beta

- [X] Ability to predefine filtering options in script dataset
- [X] Ability to grab data from multiple libraries simultaneously
- [ ] Titles resize? What do I do for long titles?
- [ ] Book information pops up when clicked
- [ ] (Stretch goal) Work with Lulu xPress

Signed-off-by: Henry Agnew <henryd.agnew@gmail.com>