### PR TITLE
Self Initialize Glossarizer + localStorage

### DIFF
--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -54,10 +54,11 @@ class LibreTextsGlossarizer {
         }
         return cols;
     }
-    async makeGlossary(sourceOption) {
+    async makeGlossary(inputSourceOption) {
         if (!this.isArticleTopicPage()) { //If article isn't a topic page, don't do anything
             return;
         }
+        let sourceOption = inputSourceOption || localStorage.getItem("glossarizerType");
         let pluginName = this.pluginName;
         let defaults = this.defaults;
         let getTermCols = this.getTermCols;

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -14,7 +14,7 @@ class LibreTextsGlossarizer {
             caseSensitive: false,
             exactMatch: true
         };
-        if (typeof(localStorage.glossarizerType) == "undefined" || localStorage.getItem("glossaryType") === null) {
+        if (typeof(localStorage.glossarizerType) == "undefined" || !localStorage.getItem("glossarizerType")) {
             localStorage.setItem("glossarizerType", "textbook");
         }
 
@@ -669,5 +669,7 @@ class LibreTextsGlossarizer {
 
 
 //Self Initialize
-let libretextGlossary = new LibreTextsGlossarizer();
-libretextGlossary.makeGlossary();
+let libretextGlossary = new LibreTextsGlossarizer(); // Needs to be accessible to the sidebar buttons
+window.addEventListener('load', ()=>{
+    libretextGlossary.makeGlossary();
+});


### PR DESCRIPTION
Add local storage and Self initialize glossarizer
Also fixed small bug that makes undefined terms appear

https://chem.libretexts.org/Bookshelves/Biological_Chemistry/Book3A_Medicines_by_Design/01%3A_ABCs_of_Pharmacology/1.03%3A_Fitting_In
can enter the line below with other inputs to see the different outcomes, I wouldn't touch goldbook though 
`libretextGlossary.makeGlossary("textbook")`