### PR TITLE
remove colon and chem glossaries

### DIFF
--- a/public/Aryan Suri/Sidebar/sidebar.js
+++ b/public/Aryan Suri/Sidebar/sidebar.js
@@ -474,12 +474,12 @@ async function Sidebar() {
 
 			</div>
 	</div>
-	<div id="glossarizerOptions" class="custom_field" ><p class="mt-icon-bubble2">&nbsp;Glossary:</p>
+	<div id="glossarizerOptions" class="custom_field" ><p class="mt-icon-bubble2">&nbsp;Glossary</p>
 		<form oninput="libretextGlossary.makeGlossary(glossarizerOptions.value)">
 		    <p><input id="glossarizerOptionstextbook" name="glossarizerOptions" type="radio" value="textbook"/><label class="glossaryLabel" for="textbook">Textbook</label></p>
-		    <p><input id="glossarizerOptionsachem" name="glossarizerOptions" type="radio" value="achem"/><label class="glossaryLabel" for="achem">Analytical Library</label></p>
+		    <!-- <p><input id="glossarizerOptionsachem" name="glossarizerOptions" type="radio" value="achem"/><label class="glossaryLabel" for="achem">Analytical Library</label></p>
 		    <p><input id="glossarizerOptionsichem" name="glossarizerOptions" type="radio" value="ichem"/><label class="glossaryLabel" for="ichem">Inorganic Library</label></p>
-		    <p><input id="glossarizerOptionsochem" name="glossarizerOptions" type="radio" value="ochem"/><label class="glossaryLabel" for="ochem">Organic Library</label></p>
+		    <p><input id="glossarizerOptionsochem" name="glossarizerOptions" type="radio" value="ochem"/><label class="glossaryLabel" for="ochem">Organic Library</label></p> -->
 		    <p><input id="glossarizerOptionsnone" name="glossarizerOptions" type="radio" value="none"/><label class="glossaryLabel" for="none">None</label></p>
 		</form>
     	</div>


### PR DESCRIPTION
https://chem.libretexts.org/Bookshelves/Biological_Chemistry/Book3A_Medicines_by_Design/01%3A_ABCs_of_Pharmacology/1.03%3A_Fitting_In (You'll need to block the original sidebar and glossarizer.js, but then it'll work)

quick fix to address https://librenet.groups.io/g/Tech/topic/77846286
