### PR TITLE
Fix Punctuation bug + Integrated Tippy

### DIFF
--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
@@ -1,5 +1,6 @@
 .glossarizer_replaced:hover {
     border-bottom: 1px #333 dotted;
+    background-color:#bbe2f8;
 }
 
 .glossarizer_replaced {
@@ -7,72 +8,17 @@
     display: inline;
     text-decoration-line: none;
 }
+.tippy-arrow {
+    color: #30b3f6;
+    margin: -2px;
+}
 
-.glossarizerTooltip {
+.tippy-box {
     text-align: center;
-    color: #098dd0;
+    color: #30b3f6;
     background: #e5f5fe;
-    position: absolute;
     z-index: 991;
-    padding: 15px;
-    border-radius: 5px;
-    box-sizing: border-box;
     border: 2px solid #30b3f6;
-}
-
-.glossarizerTooltip p {
-    margin-top: 0;
-}
-.glossarizerTooltip img {
-    max-height: 100px;
-}
-
-.glossarizerTooltip .caption {
-    margin-top: 0;
-}
-.glossarizerTooltip .glossarySource {
-    text-align: right;
-    margin: 0;
-}
-
-.glossarizerTooltip:before {
-    content: 'x';
-    position: absolute;
-    color: #098dd0;
-    right: 8px;
-    top: 3px;
-    font-size: 12px;
-}
-.glossarizerTooltip:after {/* triangle decoration */
-    width: 0;
-    height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 10px solid #30b3f6;
-    content: '';
-    position: absolute;
-    left: 50%;
-    bottom: -10px;
-    margin-left: -10px;
-}
-
-.glossarizerTooltip.top:after {
-    border-top-color: transparent;
-    border-bottom: 2px solid #30b3f6;
-    top: -20px;
-    bottom: auto;
-}
-
-
-.glossarizerTooltip.left:after {
-    left: 10px;
-    margin: 0;
-}
-
-.glossarizerTooltip.right:after {
-    right: 10px;
-    left: auto;
-    margin: 0;
 }
 
 .glossaryTable {

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
@@ -27,6 +27,8 @@
 .glossaryTerm {
     font-weight: bold;
 }
-.glossaryElement {
-    margin-bottom: 1em;
+
+p.glossaryElement {
+    font-size: 1.0rem;
+    margin: 0.5rem 0 1em;
 }

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -39,18 +39,22 @@ class LibreTextsGlossarizer {
     getTermCols(rowText) { // tableRows[r]
         let cols = {};
         let colStart = [
-            ['<td data-th="Word' + '(s)">', "word"],
-            ['<td data-th="Definition">', "definition"],
-            ['<td data-th="Image">', "image"],
-            ['<td data-th="Caption">', "caption"],
-            ['<td data-th="Link">', "link"],
-            ['<td data-th="Source">', "source"]
-        ]
-        let colEnd = '</td>';
+            [/(?<=\<td data-th="Word\(s\)"\>)(.|\s)*?(?=\<\/td>)/, "word"],
+            [/(?<=\<td data-th="Definition"\>)(.|\s)*?(?=\<\/td>)/, "definition"],
+            [/(?<=\<td data-th="Image"\>)(.|\s)*?(?=\<\/td>)/, "image"],
+            [/(?<=\<td data-th="Caption"\>)(.|\s)*?(?=\<\/td>)/, "caption"],
+            [/(?<=\<td data-th="Link"\>)(.|\s)*?(?=\<\/td>)/, "link"],
+            [/(?<=\<td data-th="Source"\>)(.|\s)*?(?=\<\/td>)/, "source"],
+            [/(?<=\<td data-th="Source License"\>)(.|\s)*?(?=\<\/td>)/, "license"],
+            [/(?<=\<td data-th="Author URL"\>)(.|\s)*?(?=\<\/td>)/, "sourceURL"],
+        ];
         for (let t = 0; t < colStart.length; t++) {
             let tag = colStart[t][0];
-            let colStr = rowText.substring(rowText.search(tag) + tag.length);
-            cols[colStart[t][1]] = (colStr.substring(0, colStr.search(colEnd)).trim());
+            //Test if tag exists
+            if (tag.test(rowText)) {
+                //Add contents if applicable
+                cols[colStart[t][1]] = tag.exec(rowText)[0].trim();
+            }
         }
         return cols;
     }
@@ -167,7 +171,7 @@ class LibreTextsGlossarizer {
                 };
                 //Get data from the columns in the row
                 let cols = getTermCols(tableRows[r]);
-                newTerm["term"] = cols["word"].substring(1).toLowerCase().replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+                newTerm["term"] = cols["word"].substring(0).toLowerCase().replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
 
                 //Make Description
                 if (cols["link"].length) {
@@ -182,10 +186,19 @@ class LibreTextsGlossarizer {
                 if (cols["caption"].length) {
                     cols["definition"] += `<p class = 'caption'>${cols["caption"]}</p>`;
                 }
-                if (cols["source"].length) {
-                    cols["definition"] = cols["definition"].trim() + `<p class = "glossarySource">[Source: ${cols["source"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim()}]</p>`;
+                let termSource = "";
+                if (cols["license"].length) {
+                    termSource += cols["license"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
                 }
-
+                if (cols["source"].length) {
+                    termSource += (termSource.length ? "; " : "") + cols["source"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+                }
+                /*if (cols["sourceURL"].length) { //Need to make source URL work (Check for whether a tag is present, or else use text as url)
+                    cols["definition"] = cols["definition"].trim() + cols["sourceURL"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+                }*/
+                if (termSource.length) {
+                    cols["definition"] = cols["definition"].trim() + `<p class = "glossarySource">[${termSource}]</p>`;
+                }
                 newTerm["description"] = cols["definition"];
 
                 //Add new term
@@ -195,7 +208,7 @@ class LibreTextsGlossarizer {
                     if (terms[t].trim() === "" || terms[t].includes("!")) {
                         continue;
                     }
-                    retrievedGlossary.push({"term": terms[t], "description": newTerm["description"]});
+                    retrievedGlossary.push({"term": terms[t].trim(), "description": newTerm["description"]});
                 }
                 } else {
                     retrievedGlossary.push(newTerm);
@@ -251,7 +264,7 @@ class LibreTextsGlossarizer {
             /* Fetch glossary JSON */
             //Trim the content to remove the example table
 
-            base.glossary = retrievedGlossary.splice(0);
+            base.glossary = retrievedGlossary.slice(0);
 
             if (!base.glossary.length || base.glossary.length == 0) return;
             /**
@@ -429,30 +442,6 @@ class LibreTextsGlossarizer {
         }
 
         /**
-         * Public Methods
-         */
-
-        let methods = {
-            destroy: function () {
-                this.$el.removeData('plugin_' + pluginName)
-
-                /* Remove abbr tag */
-                this.$el.find('.' + this.options.replaceClass).each(function () {
-                    let $this = $(this),
-                        text = $this.text()
-
-                    $this.replaceWith(text)
-                })
-            }
-        }
-
-        /**
-         * Extend Prototype
-         */
-
-        Glossarizer.prototype = $.extend({}, Glossarizer.prototype, methods);
-
-        /**
          * Plugin
          * @param  {[type]} options
          */
@@ -500,7 +489,6 @@ class LibreTextsGlossarizer {
             }
             return -1
         }
-
 
         //Initialise Glossariser
         $(function () {
@@ -556,8 +544,16 @@ class LibreTextsGlossarizer {
             //Get cells in the 3 columns
             let cols = this.getTermCols(tableRows[r]);
             if (cols["definition"].trim().length === 0 || cols["word"].trim().length === 0) continue; // Handle empty terms and definitions
+            let termSource = "";
+            if (cols["license"].length) {
+                termSource += cols["license"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+            }
             if (cols["source"].length) {
-                cols["definition"] = cols["definition"].trim() + ` [Source: ${cols["source"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim()}]`;
+                termSource += (termSource.length ? "; " : "") + cols["source"].replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+            }
+            
+            if (termSource.length) {
+                cols["definition"] = cols["definition"].trim() + ` [${termSource}]`;
             }
             if (cols["link"].length) {
                 let aTagStart = 'href="';
@@ -567,8 +563,8 @@ class LibreTextsGlossarizer {
             } else {
                 newTerm["description"] = `<span class = "glossaryDefinition">${cols["definition"].trim()}</span>`;
             }
-            let currentTerm = cols["word"].substring(1).split(",")[0].trim();
-            newTerm["term"] = `<span class = "glossaryTerm">${currentTerm.substring(0,1).toUpperCase() + currentTerm.substring(1)}</span>`;
+            let currentTerm = cols["word"].substring(0).split(",")[0].trim();
+            newTerm["term"] = `<span class = "glossaryTerm">${currentTerm}</span>`;
             glossaryList.push(newTerm);
         }
         glossaryList.sort((a, b) => {

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -171,7 +171,7 @@ class LibreTextsGlossarizer {
                 };
                 //Get data from the columns in the row
                 let cols = getTermCols(tableRows[r]);
-                newTerm["term"] = cols["word"].substring(0).toLowerCase().replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
+                newTerm["term"] = cols["word"].toLowerCase().replace(/<p>/g, " ").replace(/<\/p>/g, " ").trim();
 
                 //Make Description
                 if (cols["link"].length) {
@@ -263,8 +263,8 @@ class LibreTextsGlossarizer {
 
             /* Fetch glossary JSON */
             //Trim the content to remove the example table
-
-            base.glossary = retrievedGlossary.slice(0);
+            //Shallow Copy
+            base.glossary = [...retrievedGlossary];
 
             if (!base.glossary.length || base.glossary.length == 0) return;
             /**
@@ -563,7 +563,7 @@ class LibreTextsGlossarizer {
             } else {
                 newTerm["description"] = `<span class = "glossaryDefinition">${cols["definition"].trim()}</span>`;
             }
-            let currentTerm = cols["word"].substring(0).split(",")[0].trim();
+            let currentTerm = cols["word"].split(",")[0].trim();
             newTerm["term"] = `<span class = "glossaryTerm">${currentTerm}</span>`;
             glossaryList.push(newTerm);
         }

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -303,7 +303,7 @@ class LibreTextsGlossarizer {
 
                 for (let i = 0; i < this.glossary.length; i++) {
                     if (this.options.exactMatch) {
-                        if (this.glossary[i].term.toLowerCase() == this.clean(term).toLowerCase()) {
+                        if (this.glossary[i].term == term.toLowerCase()) {
                             return this.glossary[i].description.replace(/\"/gi, '&quot;')
                         }
                     } else {

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -39,21 +39,21 @@ class LibreTextsGlossarizer {
     getTermCols(rowText) { // tableRows[r]
         let cols = {};
         let colStart = [
-            [/(?<=\<td data-th="Word\(s\)"\>)(.|\s)*?(?=\<\/td>)/, "word"],
-            [/(?<=\<td data-th="Definition"\>)(.|\s)*?(?=\<\/td>)/, "definition"],
-            [/(?<=\<td data-th="Image"\>)(.|\s)*?(?=\<\/td>)/, "image"],
-            [/(?<=\<td data-th="Caption"\>)(.|\s)*?(?=\<\/td>)/, "caption"],
-            [/(?<=\<td data-th="Link"\>)(.|\s)*?(?=\<\/td>)/, "link"],
-            [/(?<=\<td data-th="Source"\>)(.|\s)*?(?=\<\/td>)/, "source"],
-            [/(?<=\<td data-th="Source License"\>)(.|\s)*?(?=\<\/td>)/, "license"],
-            [/(?<=\<td data-th="Author URL"\>)(.|\s)*?(?=\<\/td>)/, "sourceURL"],
+            [/(\<td data-th="Word\(s\)"\>)((.|\s)*?)(?=\<\/td>)/, "word"],
+            [/(\<td data-th="Definition"\>)((.|\s)*?)(?=\<\/td>)/, "definition"],
+            [/(\<td data-th="Image"\>)((.|\s)*?)(?=\<\/td>)/, "image"],
+            [/(\<td data-th="Caption"\>)((.|\s)*?)(?=\<\/td>)/, "caption"],
+            [/(\<td data-th="Link"\>)((.|\s)*?)(?=\<\/td>)/, "link"],
+            [/(\<td data-th="Source"\>)((.|\s)*?)(?=\<\/td>)/, "source"],
+            [/(\<td data-th="Source License"\>)((.|\s)*?)(?=\<\/td>)/, "license"],
+            [/(\<td data-th="Author URL"\>)((.|\s)*?)(?=\<\/td>)/, "sourceURL"],
         ];
         for (let t = 0; t < colStart.length; t++) {
             let tag = colStart[t][0];
             //Test if tag exists
             if (tag.test(rowText)) {
                 //Add contents if applicable
-                cols[colStart[t][1]] = tag.exec(rowText)[0].trim();
+                cols[colStart[t][1]] = tag.exec(rowText)[2].trim();
             }
         }
         return cols;

--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.js
@@ -501,112 +501,30 @@ class LibreTextsGlossarizer {
             return -1
         }
 
-        //Tooltip Constructor
-        // 
-        // Author : http://osvaldas.info/elegant-css-and-jquery-tooltip-responsive-mobile-friendly
-        // 
-        // 
-        // Author : http://osvaldas.info/elegant-css-and-jquery-tooltip-responsive-mobile-friendly
-        // 
-
-        function ToolTip() {
-            let targets = $("." + defaults.replaceClass),
-                target = false,
-                tooltip = false,
-                title = false;
-
-            targets.bind('mouseenter', function () {
-                target = $(this);
-                let tip = target.attr('title');
-                tooltip = $(`<div id="tooltip${target.text()}" class= "glossarizerTooltip"></div>`);
-                let inputs = {
-                    "tooltip": tooltip,
-                    "target": target,
-                    "tip": tip
-                };
-                if (!tip || tip == '')
-                    return false;
-
-                target.removeAttr('title');
-                tooltip.html(tip).appendTo('body');
-
-                let init_tooltip = function () {
-                    tooltip.css('max-width', "");
-                    if ($(window).width() <= tooltip.outerWidth() * 2)
-                        tooltip.css('max-width', $(window).width() / 2);
-                    else
-                        tooltip.css('max-width', 340);
-
-                    let pos_left = target.offset().left + (target.outerWidth() / 2) - (tooltip.outerWidth() / 2);
-
-                    if (pos_left < 0) {
-                        pos_left = target.offset().left + target.outerWidth() / 2 - 20;
-                        tooltip.addClass('left');
-                    } else
-                        tooltip.removeClass('left');
-
-                    if (pos_left + tooltip.outerWidth() > $(window).width()) {
-                        pos_left = target.offset().left - tooltip.outerWidth() + target.outerWidth() / 2 + 20;
-                        tooltip.addClass('right');
-                    } else
-                        tooltip.removeClass('right');
-
-                    let pos_top = target.offset().top - tooltip.outerHeight() - 20;
-
-                    if (pos_top < 0) {
-                        pos_top = target.offset().top + target.outerHeight();
-                        tooltip.addClass('top');
-                    } else
-                        tooltip.removeClass('top');
-
-
-                    tooltip.css({
-                        left: pos_left,
-                        top: pos_top,
-                    }).fadeIn();
-                };
-
-                init_tooltip();
-                $(window).resize(init_tooltip);
-
-
-                function remove_tooltip(inputs) {
-
-                    inputs.target.attr("title", inputs.tip);
-                    inputs.tooltip.fadeOut();
-                    inputs.tooltip.remove();
-
-                }
-                if (tooltip.html().includes("<img")) {
-                    $(`#tooltip${target.text()} img`).on("load", init_tooltip);
-                }
-
-                tooltip.bind("mouseleave", () => {
-                    remove_tooltip(inputs);
-                });
-                tooltip.bind('click', () => {
-                    remove_tooltip(inputs);
-                });
-                target.bind('mouseleave', () => {
-                    setTimeout((inputs) => {
-                        if ($(`#tooltip${inputs.target.text()}:hover`).length == 0) {
-                            remove_tooltip(inputs);
-                        }
-                    }, 300, inputs);
-                });
-            });
-
-        }
-
-        window.tooltip = ToolTip;
-
-
 
         //Initialise Glossariser
         $(function () {
             $('.mt-content-container').glossarizer({
                 callback: function () {
-                    new tooltip();
+                    tippy("." + defaults.replaceClass, {
+                        content(reference) {
+                          const title = reference.getAttribute('title');
+                          reference.removeAttribute('title');
+                          return title;
+                        },
+                        allowHTML: true,
+                        delay: [1000, null],
+                        popperOptions: {
+                            modifiers: [
+                                {
+                                  name: 'preventOverflow',
+                                  options: {
+                                    padding: {left:30}, // Prevent clipping sidebar
+                                  },
+                                },
+                              ],
+                          },
+                     });
                 }
             });
 


### PR DESCRIPTION
Allowed Glossarizer to match terms with punctuation like brackets in them, updated Regex used to read the glossary
Used Tippy to accommodate these changes

https://chem.libretexts.org/Bookshelves/Biological_Chemistry/Book3A_Medicines_by_Design/01%3A_ABCs_of_Pharmacology/1.03%3A_Fitting_In
(The original libretextsGlossarizer css and js need to be blocked)
Check "dna" vs "dna (Deoxyribonucleic Acid)"