### PR TITLE
Fixed remaining h5

### DIFF
--- a/public/Aryan Suri/Sidebar/sidebar.js
+++ b/public/Aryan Suri/Sidebar/sidebar.js
@@ -475,20 +475,20 @@ async function Sidebar() {
 		
         </div>` : `<div id="sbHeader" class="sbHeader" style="">
         <div id="openContents"  class="top-tabs">
-			<h5  >Contents</h5>
+			<div class="top-tab">Contents</div>
 		</div>
 		<div  id="openResources" class="top-tabs">
-            <h5 class="">Resources</h5>
+            <div class="top-tab">Resources</div>
 		</div>
 		<div id="openControl"  class="top-tabs">
-			<h5 >Readability</h5>
+			<div class="top-tab">Readability</div>
 		</div>
 		<div  id="openUsage"  class="top-tabs">
-            <h5 class="">Tools</h5>
+            <div class="top-tab">Tools</div>
 		</div>
 
 		<div id="openLibreverse"  class="top-tabs">
-            <h5  class="">LibreVerse</h5>
+            <div class="top-tab">LibreVerse</div>
 		</div>
         </div>`,
             "home": `<div id="sb1" class="custom_sidebar">


### PR DESCRIPTION
Continuation of #110 
While you did get the "pro" tabs, you forgot the other half of the ternary.

![image](https://user-images.githubusercontent.com/12994749/104551734-4862a800-55ec-11eb-8ce2-b6cfc318d85e.png)
 I copied what you did in #110 and applied it to the remaning h5.