### PR TITLE
fix tippy shifting text

### DIFF
--- a/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
+++ b/public/Leo Jayachandran/Glossarizer/libretextsGlossarizer.css
@@ -20,6 +20,9 @@
     z-index: 991;
     border: 2px solid #30b3f6;
 }
+[data-tippy-root] {
+    display: inline;
+}
 
 .glossaryTable {
     display: none;


### PR DESCRIPTION
https://chem.libretexts.org/Bookshelves/Biological_Chemistry/Book3A_Medicines_by_Design/zz3A_Back_Matter/20%3A_Glossary
^Test demo page

a div that tippy relied on defaulted to display block because of MindTouch. Should fix the bug where definitions shift off