### PR TITLE
Fix/Improvements to Cite/Attr Modal

### DIFF
--- a/public/Aryan Suri/Citation/attribution.js
+++ b/public/Aryan Suri/Citation/attribution.js
@@ -12,7 +12,8 @@ function attribution() {
         }
         let titlestr = `"${title}"`;
         let pageID = $("#pageIDHolder").text();
-        let url = `https://chem.libretexts.org/@go/page/${pageID}`;
+        let currentLibrary = window.location.host.split('.')[1] ? window.location.host.split('.')[0] : 'chem';
+        let url = `https://${currentLibrary}.libretexts.org/@go/page/${pageID}`;
         let isauthor = Boolean(author);
         let iscc = Boolean(cc);
         try {
@@ -47,34 +48,36 @@ function attribution() {
             <div onclick="hideattr()" id="attrModal">
 
                 <div id="attrModalContent" style="cursor: pointer" >
+                    <span class="closeModal">×</span>
+                    <h5 id="modalTitle">Get Page Attribution</h5>
                     
                     <div id="attrHTML">
                     </div>
 
 
                     <div id="attr-links">
-                        <a id="attr-copy" style="text-decoration: none; color: #666" >Copy Text</a>
-                        <a id="attr-html" style="text-decoration: none; color: #666" >Copy HTML</a>
-                        <a id="attr-author" style="text-decoration: none; color: #666"> Affiliation's Page</a>
-                        <a id="attr-program" style="text-decoration: none; color: #666"> Program's Page</a>
+                        <a id="attr-copy">Copy Text</a>
+                        <a id="attr-html">Copy HTML</a>
+                        <a id="attr-author"> Affiliation's Page</a>
+                        <a id="attr-program"> Program's Page</a>
                     </div>
                 </div>
 
             </div>`);
         if (param.cc) {
             if (param.isauthor) {
-                $("#attrHTML").html(`<p id="attr-text"> <a href="${param.url}"> ${param.title} </a> by <a id="attr-author-link" href="">${param.author}</a>, <a href="https://libretexts.org/">LibreTexts</a> is licensed under <a href="${cc.link}"> ${cc.title} </a>.  </p> <br/>`);
+                $("#attrHTML").html(`<p id="attr-text"><a href="${param.url}">${param.title}</a> by <a id="attr-author-link" href="">${param.author}</a>, <a href="https://libretexts.org/">LibreTexts</a> is licensed under <a href="${cc.link}"> ${cc.title} </a>.</p><br/>`);
             }
             else {
-                $("#attrHTML").html(`<p id="attr-text"> <a href="${param.url}"> ${param.title} </a> by <a href="https://libretexts.org/">LibreTexts</a> is licensed under <a href="${cc.link}"> ${cc.title} </a>.  </p> <br/>`);
+                $("#attrHTML").html(`<p id="attr-text"> <a href="${param.url}">${param.title}</a> by <a href="https://libretexts.org/">LibreTexts</a> is licensed under <a href="${cc.link}"> ${cc.title}</a>.</p><br/>`);
             }
         }
         else {
             if (param.isauthor) {
-                $("#attrHTML").html(`<p id="attr-text"> <a href="${param.url}"> ${param.title} </a> by <a id="attr-author-link" href="">${param.author}</a>, <a href="https://libretexts.org/">LibreTexts</a> has no license indicated.  </p> <br/>`);
+                $("#attrHTML").html(`<p id="attr-text"><a href="${param.url}">${param.title}</a> by <a id="attr-author-link" href="">${param.author}</a>, <a href="https://libretexts.org/">LibreTexts</a> has no license indicated.  </p><br/>`);
             }
             else {
-                $("#attrHTML").html(`<p id="attr-text"> <a href="${param.url}"> ${param.title} </a> by <a href="https://libretexts.org/">LibreTexts</a> has no license indicated.  </p> <br/>`);
+                $("#attrHTML").html(`<p id="attr-text"><a href="${param.url}">${param.title}</a> by <a href="https://libretexts.org/">LibreTexts</a> has no license indicated.</p><br/>`);
             }
         }
         const attrCopy = document.getElementById("attr-copy");

--- a/public/Aryan Suri/Citation/citation.css
+++ b/public/Aryan Suri/Citation/citation.css
@@ -1,70 +1,75 @@
+#attrModal,
 #asModal {
-    display: flex;
+    display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 9999;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
-    overflow: none;
-    background-color: none;
-    justify-content: center;
-    align-content: center;
+    overflow: auto;
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0,0.4);
 }
-
-#asModalContent {
-    background-color: #fefefe;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 40vw;
-    z-index: 30000001;
-    margin-left: 0px;
-    top: calc(50% - 150px);
-    position: absolute;
-    border-radius: 10px;
-}
-
-
-#attrModal {
-    display: flex;
-    position: fixed;
-    z-index: 1;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: none;
-    background-color: none;
-    justify-content: center;
-    align-content: center;
-  }
   
-  #attrModalContent {
-    background-color: #fefefe;
+#attrModalContent,
+#asModalContent {
+    background-color: white;
+    margin: 15% auto;
     padding: 20px;
     border: 1px solid #888;
-    width: 40vw;
-    z-index: 30000001;
-    margin-left: 0;
-    top: calc(50% - 137px);
-    position: absolute;
-    border-radius: 10px;
-  } 
+    width: 40%;
+    font-size: 18px;
+}
+ 
+span.closeModal {
+    color: black;
+    float: right;
+    font-size: 1.3em;
+    font-weight: bold;
+    line-height: 1em;
+    vertical-align: middle;
+}
+span.closeModal:hover,
+span.closeModal:focus {
+    color: red;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+ h5#modalTitle {
+    margin: 0 !important;
+    padding: 0;
+    font-weight: normal;
+    color: black;
+    border-bottom: 1px solid lightgrey;
+    padding-bottom: 0.75em;
+    font-size: 1.3em;
+}
   
 #citeContent, #attr-links {
-    margin-top: 10px;
+    border-top: 1px solid lightgrey;
+    padding-top: 1em;
+    margin-top: 1em;
     display: flex;
     justify-content: space-between;
 }
 
-#citeText {
-    font-size: 1rem;
+#attr-links > a,
+#citeContent > a {
+    padding: 0.5em 0.75em;
+    border-radius: 4px;
+    color: #555;
+    font-size: 1em;
+}
+#attr-links > a:hover,
+#attr-links > a:focus
+#citeContent > a:hover,
+#citeContent > a:focus {
+    background: #efecec;
+    color: black;
 }
 
 #citeSelect {
     max-width: 30%;
-}
-
-#citeCopy:hover, #citeCopyHTML:hover, #citeBIBTEX:hover, #citeRIS:hover {
-    font-style: italic !important;
 }

--- a/public/Aryan Suri/Citation/citation.js
+++ b/public/Aryan Suri/Citation/citation.js
@@ -9,7 +9,9 @@ function buildcite() {
     $(citeDiv).html(`
 
 <div onclick="hidecite()" id="asModal">
-       <div id="asModalContent" style="cursor: pointer" >
+       <div id="asModalContent" style="cursor: pointer">
+            <span class="closeModal">×</span>
+            <h5 id="modalTitle">Cite Page</h5>
             <div  id="citeHTML">
                 <p id="citeText"> </p>
             </div>
@@ -26,10 +28,10 @@ function buildcite() {
                 </select>
             </div>
             <div id="citeContent">
-                 <a id="citeCopy" style="text-decoration: none; color: #666" >Copy Text</a>
-                 <a id="citeCopyHTML" style="text-decoration: none; color: #666" >Copy HTML</a>
-                 <a id="citeBIBTEX" style="text-decoration: none; color: #666" >Download BibTeX </a>
-                 <a id="citeRIS" style="text-decoration: none; color: #666" >Download RIS </a>
+                 <a id="citeCopy">Copy Text</a>
+                 <a id="citeCopyHTML">Copy HTML</a>
+                 <a id="citeBIBTEX">Download BibTeX </a>
+                 <a id="citeRIS">Download RIS </a>
             </div>
        </div>
 </div>


### PR DESCRIPTION
Issue: #165 

## Change log

- changes apply to "Get Page Citation" and "Get Page Attribution" links of LT pages
- use subdomain from `window.location` to build URL for attribution links
- add heading and close ("x") button to modal
- remove inline css
- add various styling improvements
