### PR TITLE
Hotfixed propagator functionality

### DIFF
--- a/public/Miscellaneous/copyNavigation.js
+++ b/public/Miscellaneous/copyNavigation.js
@@ -39,8 +39,9 @@
     }
     
     async function askPropagator() {
-        if (confirm(`Propagate ${window.location.href} to the other libraries?`)) {
-            let url = window.location.href;
+        const [subdomain, path] = LibreTexts.parseURL();
+        let url = `https://${subdomain}.libretexts.org/${path}`;
+        if (confirm(`Propagate ${url} to the other libraries?`)) {
             const subdomain = url.split("/")[2].split(".")[0];
             //Disabled for careered
             let otherArray = ["bio", "biz", "chem", "eng", "espanol", "geo", "human", "math", "med", "phys", "socialsci", "stats", "workforce"];


### PR DESCRIPTION
Swapped to parseURL since it properly strips the `#` at the end of the URL. Note that this is a front-end fix, not a back-end fix.

### Problem overview:
The Propagator has been broken for a while since the "Options" button has been changed so that it has `href="#"`.
![image](https://user-images.githubusercontent.com/12994749/146836825-7236d58c-ceec-4145-8549-1b407f36ae56.png)
This href modifies the URL and causes issues for the API.

In order to fix this, I have swapped to the LibreTexts.parseURL helper function since it is able to properly strip the trailing `#` and query parameters. Using Local Overrides, I have tested the change and it appears to now be working again.



### Before:
<img width="547" alt="Before" src="https://user-images.githubusercontent.com/12994749/146836968-f11982b4-94ff-4405-b661-6b7156f13dcd.png">

### After:
<img width="551" alt="After" src="https://user-images.githubusercontent.com/12994749/146836970-26d16a51-07bc-4e5c-b0eb-a99e2dcbf5e1.png">

