### PR TITLE
Remove mentions of deprecated miniland endpoints

### DIFF
--- a/API/timetrack.js
+++ b/API/timetrack.js
@@ -20,20 +20,8 @@ function handler(request, response) {
 	
 	if (url.startsWith("/receive")) {
 		if (request.headers.origin && request.headers.origin.endsWith("libretexts.org")) {
-			if (request.headers.host.includes(".miniland1333.com") && request.method === "OPTIONS") { //options checking
-				response.writeHead(200, {
-					"Access-Control-Allow-Origin": request.headers.origin || null,
-					"Access-Control-Allow-Methods": "POST",
-					"Content-Type": " text/plain",
-				});
-				response.end();
-			}
-			else if (request.method === "POST") {
-				response.writeHead(200, request.headers.host.includes(".miniland1333.com") ? {
-					"Access-Control-Allow-Origin": request.headers.origin || null,
-					"Access-Control-Allow-Methods": "POST",
-					"Content-Type": " text/plain",
-				} : {"Content-Type": " text/plain"});
+			if (request.method === "POST") {
+				response.writeHead(200, {"Content-Type": " text/plain"});
 				let body = [];
 				request.on('data', (chunk) => {
 					body.push(chunk);
@@ -70,20 +58,8 @@ function handler(request, response) {
 		}
 	}
 	else if (url.startsWith("/ping")) {
-		if (request.headers.host.includes(".miniland1333.com") && request.method === "OPTIONS") { //options checking
-			response.writeHead(200, {
-				"Access-Control-Allow-Origin": request.headers.origin || null,
-				"Access-Control-Allow-Methods": "GET",
-				"Content-Type": " text/plain",
-			});
-			response.end();
-		}
-		else if (request.method === "GET") {
-			response.writeHead(200, request.headers.host.includes(".miniland1333.com") ? {
-				"Access-Control-Allow-Origin": request.headers.origin || null,
-				"Access-Control-Allow-Methods": "GET",
-				"Content-Type": " text/plain",
-			} : {"Content-Type": " text/plain"});
+		if (request.method === "GET") {
+			response.writeHead(200, {"Content-Type": " text/plain"});
 			response.end();
 		}
 		else {
@@ -91,20 +67,8 @@ function handler(request, response) {
 		}
 	}
 	else if (url.startsWith("/editorStats?user=")) {
-		if (request.headers.host.includes(".miniland1333.com") && request.method === "OPTIONS") { //options checking
-			response.writeHead(200, {
-				"Access-Control-Allow-Origin": request.headers.origin || null,
-				"Access-Control-Allow-Methods": "GET",
-				"Content-Type": " text/plain",
-			});
-			response.end();
-		}
-		else if (request.method === "GET") {
-			response.writeHead(200, request.headers.host.includes(".miniland1333.com") ? {
-				"Access-Control-Allow-Origin": request.headers.origin || null,
-				"Access-Control-Allow-Methods": "GET",
-				"Content-Type": " text/plain",
-			} : {"Content-Type": " text/plain"});
+		if (request.method === "GET") {
+			response.writeHead(200, {"Content-Type": " text/plain"});
 			let user = url.split("?user=")[1];
 			user = decodeURIComponent(user);
 			getUserData(user).then((result) => {

--- a/nodePrint/nodePrint.js
+++ b/nodePrint/nodePrint.js
@@ -132,14 +132,7 @@ puppeteer.launch({
                 url = url.split('/A4')[1];
             }
             
-            if (request.headers.host === 'home.miniland1333.com' && request.method === 'OPTIONS') { //options checking
-                response.writeHead(200, {
-                    'Access-Control-Allow-Origin': request.headers.origin || null,
-                    'Access-Control-Allow-Methods': 'HEAD, GET, PUT',
-                });
-                response.end();
-            }
-            else if (url.startsWith("/url=")) { //single page
+            if (url.startsWith("/url=")) { //single page
                 url = url.split('/url=')[1];
                 
                 //query string handling
@@ -235,20 +228,8 @@ puppeteer.launch({
                 }
             }
             else if (url === '/' || url.startsWith("/ping")) {
-                if (request.headers.host && request.headers.host.includes(".miniland1333.com") && request.method === "OPTIONS") { //options checking
-                    response.writeHead(200, {
-                        "Access-Control-Allow-Origin": request.headers.origin || null,
-                        "Access-Control-Allow-Methods": "GET",
-                        "Content-Type": " text/plain",
-                    });
-                    response.end();
-                }
-                else if (["GET", "HEAD"].includes(request.method)) {
-                    response.writeHead(200, request.headers.host && request.headers.host.includes(".miniland1333.com") ? {
-                        "Access-Control-Allow-Origin": request.headers.origin || null,
-                        "Access-Control-Allow-Methods": "GET",
-                        "Content-Type": " text/plain",
-                    } : {"Content-Type": " text/plain"});
+                if (["GET", "HEAD"].includes(request.method)) {
+                    response.writeHead(200, {"Content-Type": " text/plain"});
                     response.end();
                 }
                 else {
@@ -342,11 +323,7 @@ puppeteer.launch({
                     return;
                 }
                 else {
-                    response.writeHead(200, request.headers.host.includes('.miniland1333.com') ? {
-                        'Access-Control-Allow-Origin': request.headers.origin || null,
-                        'Access-Control-Allow-Methods': 'PUT',
-                        'Content-Type': 'application/json',
-                    } : {'Content-Type': 'application/json'});
+                    response.writeHead(200, {'Content-Type': 'application/json'});
                 }
                 let body = [];
                 request.on('data', (chunk) => {
@@ -887,7 +864,7 @@ puppeteer.launch({
               // Get subtitles
               let inner = await async.map(pages, async (elem) => {
                   if (!elem.title) elem = await getAPI(elem);
-                  if (elem.modified === 'restricted') return ''; // private page 
+                  if (elem.modified === 'restricted') return ''; // private page
                   const isSubtopic = level > 2 ? `indent${level - 2}` : null;
                   const subPageDir = await getLevel(elem, level + 1, isSubTOC);
                   let hasSubpages = false;
@@ -1195,7 +1172,7 @@ puppeteer.launch({
             let stats, err, compile;
             
             if (ip.startsWith('<<Batch')) {
-              
+            
             }
             if ((working[escapedURL] && Date.now() - working[escapedURL] > 120000)) {
                 delete working[escapedURL];	//2 min timeout for DUPE
@@ -1291,7 +1268,7 @@ puppeteer.launch({
                             }
                             title.innerHTML = `<a style="color:${color}; text-decoration: none" href="${url}">${innerText}</a>`
                         }
-                        let tags = document.getElementById('pageTagsHolder').innerText;                        
+                        let tags = document.getElementById('pageTagsHolder').innerText;
                         return [prefix, innerText, tags];
                     }, url);
                     let prefix = out[0];
@@ -1676,7 +1653,7 @@ puppeteer.launch({
                             title = `00000:${String.fromCharCode(64 + page.index)} ${page.title}`;
                         } else {
                             title = `99999:${String.fromCharCode(64 + page.miniIndex)} ${page.title}`;
-                        }  
+                        }
                     } else if (page.subpages && page.subpages.length > 1 && page.tags && (page.tags.includes('article:topic-category') || page.tags.includes('article:topic-guide'))) {
                         filename = `TOC/${await getTOC(page)}.pdf`;
                         
@@ -1859,7 +1836,7 @@ puppeteer.launch({
                     }
                 } catch (e) {
                     console.error(`Error creating zip files ${zipFilename}`);
-                    console.error(e);   
+                    console.error(e);
                 }
             }
             const end = performance.now();

--- a/public/Henry Agnew/API Dashboard/src/components/BatchMonitor.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/BatchMonitor.jsx
@@ -22,7 +22,7 @@ export default function BatchMonitor(props) {
     const [toBatch, setToBatch] = React.useState(initializeLibraryObject);
     const [dialogOpen, setDialogOpen] = React.useState(false);
     const [allBatch, setAllBatch] = React.useState({courses: 'unchecked', bookshelves: 'unchecked'});
-    const batchEndpoint = props.devMode ? 'https://home.miniland1333.com/print' : 'https://batch.libretexts.org/print'
+    const batchEndpoint = 'https://batch.libretexts.org/print'
     const pathStyle = {cursor: 'pointer', userSelect: 'none'};
     
     useEffect(() => {

--- a/public/Henry Agnew/API Dashboard/src/components/ConvertContainers.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/ConvertContainers.jsx
@@ -28,7 +28,8 @@ export default class ConvertContainers extends React.Component {
     }
     
     componentDidMount() {
-        this.socket = io(this.props.devMode ? 'https://home.miniland1333.com/' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API Dashboard/src/components/DeadLinks.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/DeadLinks.jsx
@@ -28,7 +28,8 @@ export default class DeadLinks extends React.Component {
     }
     
     componentDidMount() {
-        this.socket = io(this.props.devMode ? 'https://home.miniland1333.com/' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API Dashboard/src/components/FindReplace.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/FindReplace.jsx
@@ -33,7 +33,8 @@ export default class FindReplace extends React.Component {
     }
     
     componentDidMount() {
-        this.socket = io(this.props.devMode ? 'https://home.miniland1333.com/' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API Dashboard/src/components/ForeignImage.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/ForeignImage.jsx
@@ -28,7 +28,8 @@ export default class ForeignImage extends React.Component {
     }
     
     componentDidMount() {
-        this.socket = io(this.props.devMode ? 'https://home.miniland1333.com/' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API Dashboard/src/components/HeaderFix.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/HeaderFix.jsx
@@ -28,7 +28,8 @@ export default class HeaderFix extends React.Component {
     }
     
     componentDidMount() {
-        this.socket = io(this.props.devMode?'https://home.miniland1333.com/':'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API Dashboard/src/components/LicenseReport.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/LicenseReport.jsx
@@ -30,7 +30,8 @@ export default class LicenseReport extends React.Component {
     }
 
     componentDidMount() {
-        this.socket = io(this.props.devMode?'https://home.miniland1333.com/':'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('setState', (data) => {
             switch (data.state) {
                 case 'starting':

--- a/public/Henry Agnew/API Dashboard/src/components/Multi.jsx
+++ b/public/Henry Agnew/API Dashboard/src/components/Multi.jsx
@@ -29,7 +29,8 @@ export default class Multi extends React.Component {
     }
 
     componentDidMount() {
-        this.socket = io(this.props.devMode ? 'https://home.miniland1333.com/' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        // this.socket = io(this.props.devMode ? '<dev endpoint>' : 'https://api.libretexts.org/', {path: '/bot/ws'});
+        this.socket = io('https://api.libretexts.org/', {path: '/bot/ws'});
         this.socket.on('pages', (data) => {
             // console.log(data);
             let tempResults = data.concat(this.state.results);

--- a/public/Henry Agnew/API/analytics.js
+++ b/public/Henry Agnew/API/analytics.js
@@ -9,7 +9,6 @@ if (!window["analytics.js"]) {
         const root = "api.libretexts.org";
         let coverpage;
         let login = '';
-        // const root = "home.miniland1333.com"
         
         
         if (navigator.webdriver || isUserAutomated || window.matchMedia('print').matches) {


### PR DESCRIPTION
Removes all references to deprecated `miniland1333` endpoints. This endpoint was used for alpha testing long ago and the domain is no longer used.

Closes #209