### PR TITLE
fix(nodePrint): stop clearing aged items

### DIFF
--- a/nodePrint/nodePrint.js
+++ b/nodePrint/nodePrint.js
@@ -399,17 +399,17 @@ puppeteer.launch({
                     response.end();
                     
                     //Remove all files older than 2 months.
-                    console.log(`Cleaning...`);
+                    // console.log(`Cleaning...`);
                     /*let count = 0;
                     let heartbeat = setInterval(() => {
                         if (response && !response.finished)
                             response.write(`${(++count)}s\r\n`.padStart(5, ' '))
                     }, 1000);*/
-                    findRemoveSync('./PDF', {
-                        age: {seconds: maxAge * 8.64e+4},
-                        // dir: "*",
-                        files: "*.*",
-                    });
+                    // findRemoveSync('./PDF', {
+                    //     age: {seconds: maxAge * 8.64e+4},
+                    //     // dir: "*",
+                    //     files: "*.*",
+                    // });
                     
                     
                     for (const library of toBatch) {


### PR DESCRIPTION
@ethanaturner I believe this is what's causing so many PDFs to go missing - they're aging out before the cron job comes back around to refresh them. Probably best to leave them be so that a copy is always available until they a refreshed.